### PR TITLE
fix(toolbox): case where embed description is empty

### DIFF
--- a/docs/implementation-summary.md
+++ b/docs/implementation-summary.md
@@ -24,6 +24,7 @@ parent: Technical Documentation
 **File:** `src/functions/systemLogger.js`, `src/database/modules/systemLog.js`
 
 **Features:**
+
 -   **Database-Backed Logging**: All system events now persist in database via SystemLog model
 -   **Comprehensive Event Tracking**: Command usage, guild events, crisis events, moderation actions, errors
 -   **Guild-Specific Logs**: Queryable historical logs by guild and log type
@@ -32,6 +33,7 @@ parent: Technical Documentation
 -   **Smart Channel Routing**: Automatic routing to appropriate Discord channels based on log type
 
 **Database Schema:**
+
 ```sql
 model SystemLog {
   id          String   @id @default(cuid())
@@ -51,6 +53,7 @@ model SystemLog {
 **File:** `src/commands/slash/guild/guilddebug.js`
 
 **Comprehensive Diagnostic Tool:**
+
 -   **`/guilddebug diagnostics`** - Complete guild health analysis with performance metrics
 -   **`/guilddebug settings`** - Detailed configuration review (Mellow team only)
 -   **`/guilddebug logs`** - Advanced log viewing with type filtering (Mellow team only)
@@ -59,6 +62,7 @@ model SystemLog {
 -   **`/guilddebug join-guild`** - Staff invite generation for guild access (Mellow team only)
 
 **Permission Levels:**
+
 -   **Public Access**: `request-support` for guild administrators
 -   **Mellow Team Only**: All diagnostic commands with sensitive information
 -   **Smart Fallbacks**: Graceful handling of missing permissions or data
@@ -68,6 +72,7 @@ model SystemLog {
 **File:** `src/services/twitter.service.js`, `src/configs/twitter.config.js`
 
 **Social Media Automation:**
+
 -   **AI-Powered Content Generation**: Daily tips, weekly updates, awareness posts
 -   **Automated Scheduling**: Configurable posting times and frequencies
 -   **Content Moderation**: Built-in filtering and approval workflows
@@ -76,6 +81,7 @@ model SystemLog {
 -   **Management Commands**: `/twitter status`, `/twitter post`, `/twitter schedule`
 
 **Enhanced Error Handling:**
+
 -   **403 Forbidden Diagnostics**: Specific guidance for API permission issues
 -   **Connection Testing**: Automatic credential validation and troubleshooting
 -   **Fallback Responses**: Graceful degradation when service unavailable
@@ -85,6 +91,7 @@ model SystemLog {
 **File:** `src/services/support.service.js`
 
 **Professional Support System:**
+
 -   **Automated Ticket Management**: Thread creation and routing in support server
 -   **Severity-Based Escalation**: Critical issues ping support team immediately
 -   **Integration with Guild Debug**: Seamless flow from diagnostics to support
@@ -99,6 +106,7 @@ model SystemLog {
 **File:** `src/commands/slash/guild/guildsettings.js`
 
 **Complete Rebuild:**
+
 -   **Fixed Channel Configuration**: Now properly saves all channel settings (crisis alerts, mod logs, system logs)
 -   **Feature Toggles**: Working controls for check-ins, crisis alerts, context logging
 -   **Database Integrity**: Fixed upsert operations with proper field validation
@@ -110,6 +118,7 @@ model SystemLog {
 **Files:** `src/database/modules/guild.js`, `src/database/modules/systemLog.js`
 
 **Enhanced Guild Management:**
+
 -   **Helper Methods**: `getSettings()`, `exists()`, `updateChannels()`, `updateRoles()`, `updateFeatures()`
 -   **BigInt Migration**: Fixed critical Discord ID conversion bugs causing lookup failures
 -   **String ID Handling**: All Discord IDs now consistently stored as strings
@@ -121,17 +130,20 @@ model SystemLog {
 **Files:** `src/commands/slash/info/guildcontext.js`, `src/commands/slash/info/stats.js`, `src/commands/slash/info/status.js`
 
 **Guild Context Command:**
+
 -   **Comprehensive Analysis**: Total messages, AI context usage, conversation tracking
 -   **Privacy-First Design**: Shows counts only, never actual content
 -   **Permission Protection**: Administrator/Manage Guild permissions required
 -   **Privacy Compliance**: Respects user and guild privacy settings
 
 **Enhanced Stats Command:**
+
 -   **Reorganized Display**: Better categorized statistics with visual improvements
 -   **Performance Metrics**: Community engagement and growth tracking
 -   **Privacy Transparency**: Clear indication of privacy settings impact
 
 **Enhanced Status Command:**
+
 -   **Rich Embed Display**: Color-coded status indicators with comprehensive metrics
 -   **System Health**: Performance, connectivity, AI service status
 -   **Dynamic Indicators**: Real-time status assessment with visual feedback
@@ -143,6 +155,7 @@ model SystemLog {
 **Files:** Multiple coping command files, `src/services/ai.service.js`
 
 **Bulletproof Reliability:**
+
 -   **AI Fallback Responses**: All coping commands work even when AI services are down
 -   **Error Recovery**: Graceful degradation with helpful fallback content
 -   **Service Health Monitoring**: Real-time AI service status tracking
@@ -151,6 +164,7 @@ model SystemLog {
 ### 9. Crisis Detection Enhancements
 
 **Integration Across Services:**
+
 -   **Multi-level Analysis**: 5-tier severity assessment (safe, low, medium, high, critical)
 -   **Smart Routing**: Appropriate responses based on crisis level
 -   **Privacy Compliance**: Respects both guild and user privacy settings
@@ -159,6 +173,7 @@ model SystemLog {
 ### 10. Reminder System Reliability
 
 **Enhanced DM Handling:**
+
 -   **Discord Error 50007 Handling**: Graceful handling when users have DMs blocked
 -   **Automatic Fallbacks**: Notifications in shared guilds when DMs fail
 -   **Smart Disabling**: Automatic reminder deactivation for unreachable users
@@ -169,6 +184,7 @@ model SystemLog {
 ### 11. Command Architecture Standardization
 
 **Consistent Patterns:**
+
 -   **Error Handling**: All commands use proper systemLogger.logError() with structured data
 -   **Permission Validation**: Robust Discord and database role checking
 -   **Response Formatting**: Consistent embed styling and user feedback
@@ -177,6 +193,7 @@ model SystemLog {
 ### 12. Service Architecture
 
 **Professional Infrastructure:**
+
 -   **Dependency Injection**: Clean service initialization and management
 -   **Health Monitoring**: Real-time service status tracking
 -   **Error Recovery**: Automatic service restart and fallback mechanisms
@@ -185,6 +202,7 @@ model SystemLog {
 ### 13. BigInt/Discord ID Migration
 
 **Critical Bug Fixes:**
+
 -   **Database Migration Scripts**: `scripts/safe-bigint-to-string-migration.sql`
 -   **ID Consistency**: All Discord IDs now handled as strings throughout codebase
 -   **Lookup Reliability**: Fixed database query failures caused by ID conversion issues
@@ -193,6 +211,7 @@ model SystemLog {
 ## 📊 Implementation Statistics
 
 **v1.2.0 Achievements:**
+
 -   **50+ Files Modified**: Comprehensive infrastructure overhaul
 -   **10 New Services**: SystemLogger, Twitter, Support, enhanced AI services
 -   **15+ Enhanced Commands**: Guild debug, settings, Twitter management, enhanced info commands
@@ -202,18 +221,21 @@ model SystemLog {
 ## 🎯 Impact & Benefits
 
 ### For Server Administrators:
+
 -   **Professional Support**: Direct access to Mellow team via `/guilddebug request-support`
 -   **Comprehensive Diagnostics**: Real-time guild health monitoring and troubleshooting
 -   **Reliable Configuration**: Guild settings that actually work and persist correctly
 -   **Enhanced Visibility**: System logs show exactly what's happening in their server
 
 ### For Mental Health Users:
+
 -   **Always-Working Tools**: Coping commands never fail, even during outages
 -   **Seamless Experience**: Enhanced error handling prevents user frustration
 -   **Consistent Support**: Reliable reminder system with intelligent fallbacks
 -   **Privacy Protection**: Enhanced privacy controls with transparent data handling
 
 ### For Developers:
+
 -   **Professional Codebase**: Standardized patterns, comprehensive error handling
 -   **Monitoring Infrastructure**: Complete visibility into system health and performance
 -   **Debugging Tools**: Advanced diagnostic capabilities for issue resolution
@@ -222,18 +244,21 @@ model SystemLog {
 ## 🔄 Next Steps & Recommendations
 
 ### Immediate Priorities:
+
 -   ✅ **Production Ready**: All v1.2.0 features tested and operational
 -   ✅ **Documentation Complete**: Comprehensive guides and troubleshooting resources
 -   ✅ **Migration Tools**: Safe upgrade paths for existing installations
 -   ✅ **Support Infrastructure**: Professional help system operational
 
 ### Future Enhancements (v1.3.0+):
+
 -   **Advanced Analytics**: Web dashboard for guild administrators
 -   **Community Features**: Peer support and social features
 -   **Mobile Integration**: Enhanced mobile app support
 -   **Advanced AI**: More sophisticated personalization and adaptation
 
 ### Monitoring & Maintenance:
+
 -   **Performance Tracking**: Monitor database query performance and optimization
 -   **Error Analysis**: Review systemLogger data for continuous improvement
 -   **User Feedback**: Track guild administrator and user satisfaction

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,10 +6,12 @@ description: 'Development roadmap and future feature plans'
 ---
 
 ---
+
 layout: default
 title: Roadmap
 nav_order: 14
 description: 'Development roadmap and future feature plans'
+
 ---
 
 # 🎯 Mellow v1.2.0 - Implementation Complete & Future Roadmap
@@ -97,6 +99,7 @@ Based on analysis of the current implementation and .todo files, here are the re
 
 -   [ ] **AI-powered mood trend predictions** using historical data
 -   [ ] **Seasonal pattern recognition** for mood tracking
+
 #### Advanced AI & Performance
 
 -   [ ] **AI-powered mood trend predictions** using historical data

--- a/docs/twitter-troubleshooting.md
+++ b/docs/twitter-troubleshooting.md
@@ -21,31 +21,34 @@ This guide helps resolve common Twitter API integration issues with Mellow Bot.
 **Solutions:**
 
 1. **Check API Credentials**
-   ```bash
-   # Verify these environment variables are set correctly:
-   TWITTER_API_KEY=your_api_key_here
-   TWITTER_API_SECRET=your_api_secret_here
-   TWITTER_ACCESS_TOKEN=your_access_token_here
-   TWITTER_ACCESS_TOKEN_SECRET=your_access_token_secret_here
-   TWITTER_BEARER_TOKEN=your_bearer_token_here
-   ```
+
+    ```bash
+    # Verify these environment variables are set correctly:
+    TWITTER_API_KEY=your_api_key_here
+    TWITTER_API_SECRET=your_api_secret_here
+    TWITTER_ACCESS_TOKEN=your_access_token_here
+    TWITTER_ACCESS_TOKEN_SECRET=your_access_token_secret_here
+    TWITTER_BEARER_TOKEN=your_bearer_token_here
+    ```
 
 2. **Verify Twitter Developer Portal Settings**
-   - Go to [Twitter Developer Portal](https://developer.twitter.com)
-   - Check your app has **Read and Write** permissions
-   - Ensure **API v2** access is enabled
-   - Verify your app is **Active** (not suspended)
+
+    - Go to [Twitter Developer Portal](https://developer.twitter.com)
+    - Check your app has **Read and Write** permissions
+    - Ensure **API v2** access is enabled
+    - Verify your app is **Active** (not suspended)
 
 3. **Regenerate Access Tokens**
-   - In Developer Portal, go to your app
-   - Navigate to "Keys and Tokens"
-   - Regenerate Access Token and Secret
-   - Update your environment variables
+
+    - In Developer Portal, go to your app
+    - Navigate to "Keys and Tokens"
+    - Regenerate Access Token and Secret
+    - Update your environment variables
 
 4. **Check Account Status**
-   - Ensure your Twitter account is not suspended
-   - Verify account is not restricted
-   - Check if account needs phone verification
+    - Ensure your Twitter account is not suspended
+    - Verify account is not restricted
+    - Check if account needs phone verification
 
 ### 401 Unauthorized Error
 
@@ -56,14 +59,15 @@ This guide helps resolve common Twitter API integration issues with Mellow Bot.
 **Solutions:**
 
 1. **Verify API Key and Secret**
-   - Check `TWITTER_API_KEY` and `TWITTER_API_SECRET`
-   - Ensure no extra spaces or characters
-   - Regenerate if necessary
+
+    - Check `TWITTER_API_KEY` and `TWITTER_API_SECRET`
+    - Ensure no extra spaces or characters
+    - Regenerate if necessary
 
 2. **Check Access Tokens**
-   - Verify `TWITTER_ACCESS_TOKEN` and `TWITTER_ACCESS_TOKEN_SECRET`
-   - Ensure tokens match your app and account
-   - Regenerate if expired
+    - Verify `TWITTER_ACCESS_TOKEN` and `TWITTER_ACCESS_TOKEN_SECRET`
+    - Ensure tokens match your app and account
+    - Regenerate if expired
 
 ### 429 Rate Limit Exceeded
 
@@ -74,12 +78,13 @@ This guide helps resolve common Twitter API integration issues with Mellow Bot.
 **Solutions:**
 
 1. **Wait Before Retrying**
-   - Rate limits reset every 15 minutes
-   - Reduce posting frequency
+
+    - Rate limits reset every 15 minutes
+    - Reduce posting frequency
 
 2. **Check Rate Limit Settings**
-   - Increase `TWITTER_POST_COOLDOWN` (default: 60 minutes)
-   - Reduce `TWITTER_DAILY_LIMIT` (default: 10 posts)
+    - Increase `TWITTER_POST_COOLDOWN` (default: 60 minutes)
+    - Reduce `TWITTER_DAILY_LIMIT` (default: 10 posts)
 
 ## Configuration Steps
 
@@ -125,11 +130,12 @@ TWITTER_INCLUDE_HASHTAGS=true
 ```
 
 This command shows:
-- Connection status
-- API credentials validation
-- Configuration settings
-- Daily posting statistics
-- Detailed error diagnostics
+
+-   Connection status
+-   API credentials validation
+-   Configuration settings
+-   Daily posting statistics
+-   Detailed error diagnostics
 
 ### Test Twitter Connection
 
@@ -142,6 +148,7 @@ The status command automatically tests the connection and provides specific erro
 **Cause:** Twitter service failed to start.
 
 **Solutions:**
+
 1. Check all environment variables are set
 2. Verify `TWITTER_POSTING_ENABLED=true`
 3. Restart the bot
@@ -152,6 +159,7 @@ The status command automatically tests the connection and provides specific erro
 **Cause:** Content moderation is enabled and flagged the content.
 
 **Solutions:**
+
 1. Review the content for policy violations
 2. Disable content moderation temporarily
 3. Modify the content to comply with policies
@@ -161,6 +169,7 @@ The status command automatically tests the connection and provides specific erro
 **Cause:** Too many posts in a short time.
 
 **Solutions:**
+
 1. Increase cooldown period
 2. Reduce daily posting limit
 3. Wait for rate limit reset
@@ -168,9 +177,10 @@ The status command automatically tests the connection and provides specific erro
 ## API Version Compatibility
 
 Mellow Bot uses **Twitter API v2** which requires:
-- Elevated access (free tier available)
-- Read and Write permissions
-- Valid OAuth 1.0a credentials
+
+-   Elevated access (free tier available)
+-   Read and Write permissions
+-   Valid OAuth 1.0a credentials
 
 ## Getting Help
 
@@ -181,19 +191,19 @@ Mellow Bot uses **Twitter API v2** which requires:
 
 ## Environment Variable Reference
 
-| Variable | Required | Description | Default |
-|----------|----------|-------------|---------|
-| `TWITTER_API_KEY` | Yes | Twitter API Key | None |
-| `TWITTER_API_SECRET` | Yes | Twitter API Secret | None |
-| `TWITTER_ACCESS_TOKEN` | Yes | Access Token | None |
-| `TWITTER_ACCESS_TOKEN_SECRET` | Yes | Access Token Secret | None |
-| `TWITTER_BEARER_TOKEN` | Optional | Bearer Token | None |
-| `TWITTER_BOT_USERNAME` | Optional | Bot Username | MellowMentalBot |
-| `TWITTER_POSTING_ENABLED` | Optional | Enable posting | false |
-| `TWITTER_POST_COOLDOWN` | Optional | Minutes between posts | 60 |
-| `TWITTER_DAILY_LIMIT` | Optional | Max posts per day | 10 |
-| `TWITTER_INCLUDE_HASHTAGS` | Optional | Include hashtags | true |
+| Variable                      | Required | Description           | Default         |
+| ----------------------------- | -------- | --------------------- | --------------- |
+| `TWITTER_API_KEY`             | Yes      | Twitter API Key       | None            |
+| `TWITTER_API_SECRET`          | Yes      | Twitter API Secret    | None            |
+| `TWITTER_ACCESS_TOKEN`        | Yes      | Access Token          | None            |
+| `TWITTER_ACCESS_TOKEN_SECRET` | Yes      | Access Token Secret   | None            |
+| `TWITTER_BEARER_TOKEN`        | Optional | Bearer Token          | None            |
+| `TWITTER_BOT_USERNAME`        | Optional | Bot Username          | MellowMentalBot |
+| `TWITTER_POSTING_ENABLED`     | Optional | Enable posting        | false           |
+| `TWITTER_POST_COOLDOWN`       | Optional | Minutes between posts | 60              |
+| `TWITTER_DAILY_LIMIT`         | Optional | Max posts per day     | 10              |
+| `TWITTER_INCLUDE_HASHTAGS`    | Optional | Include hashtags      | true            |
 
 ---
 
-*Last updated: July 3, 2025*
+_Last updated: July 3, 2025_

--- a/src/commands/slash/coping/toolbox.js
+++ b/src/commands/slash/coping/toolbox.js
@@ -131,18 +131,18 @@ export default {
                         where: { userId: BigInt(userId) }
                     })
 
+                    if (favorites.length === 0) {
+                        return interaction.reply({
+                            content: "You don't have any favorite coping tools yet. Use `/toolbox add` to add some!"
+                        })
+                    }
+
                     const embed = new client.Gateway.EmbedBuilder()
                         .setTitle('🧰 Your Favorite Coping Tools')
                         .setColor(client.colors.primary)
                         .setDescription(favorites.map(f => `• **${f.tool}**`).join('\n'))
                         .setFooter({ text: client.footer, iconURL: client.logo })
                         .setTimestamp()
-
-                    if (favorites.length === 0) {
-                        return interaction.reply({
-                            content: "You don't have any favorite coping tools yet. Use `/toolbox add` to add some!"
-                        })
-                    }
 
                     return interaction.reply({ embeds: [embed] })
                 }


### PR DESCRIPTION
The change ensures that the `/toolbox list` command no longer tries to create and send an embed with an empty description when the user has no favorite coping tools. Previously, if the favorites list was empty, the code would still attempt to build an embed with an empty string, which caused a validation error from Discord.

Now, the code first checks if the favorites list is empty. If it is, it immediately replies with a plain message telling the user they have no favorites and suggests using `/toolbox add`. Only if there are favorites does it proceed to build and send the embed listing the tools. This prevents the error and provides a better user experience.